### PR TITLE
For #8: Fixed issue with SwipeRefreshLayout

### DIFF
--- a/recyclerviewfastscroller/src/main/java/com/qtalk/recyclerviewfastscroller/RecyclerViewFastScroller.kt
+++ b/recyclerviewfastscroller/src/main/java/com/qtalk/recyclerviewfastscroller/RecyclerViewFastScroller.kt
@@ -23,12 +23,7 @@ import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
-import androidx.annotation.*
-import androidx.core.content.ContextCompat
-import androidx.core.widget.TextViewCompat
-import androidx.appcompat.widget.AppCompatImageView
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
+import android.os.Build
 import android.util.AttributeSet
 import android.util.Log
 import android.view.Gravity
@@ -39,6 +34,15 @@ import android.view.ViewPropertyAnimator
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
+import androidx.annotation.DimenRes
+import androidx.annotation.Keep
+import androidx.annotation.StyleRes
+import androidx.annotation.StyleableRes
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.content.ContextCompat
+import androidx.core.widget.TextViewCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -214,6 +218,9 @@ class RecyclerViewFastScroller @JvmOverloads constructor(
 
             trackView.background = attribs.getDrawable(R.styleable.RecyclerViewFastScroller_trackDrawable)
 
+            if (it.getBoolean(R.styleable.RecyclerViewFastScroller_supportSwipeToRefresh,false))
+                enableNestedScrolling()
+
             //align added layouts based on configurations in use.
             alignTrackAndHandle()
             alignPopupLayout()
@@ -378,6 +385,16 @@ class RecyclerViewFastScroller @JvmOverloads constructor(
     private fun addPopupLayout(){
         View.inflate(context, R.layout.fastscroller_popup, this)
         popupTextView = findViewById(R.id.fastScrollPopupTV)
+    }
+
+    /**
+     * Sets [isNestedScrollingEnabled] to true to enable support for fast scrolling when swipe
+     * refresh layout is added as parent layout.
+     */
+    private fun enableNestedScrolling() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            isNestedScrollingEnabled = true
+        }
     }
 
     /**

--- a/recyclerviewfastscroller/src/main/java/com/qtalk/recyclerviewfastscroller/RecyclerViewFastScroller.kt
+++ b/recyclerviewfastscroller/src/main/java/com/qtalk/recyclerviewfastscroller/RecyclerViewFastScroller.kt
@@ -218,8 +218,9 @@ class RecyclerViewFastScroller @JvmOverloads constructor(
 
             trackView.background = attribs.getDrawable(R.styleable.RecyclerViewFastScroller_trackDrawable)
 
-            if (it.getBoolean(R.styleable.RecyclerViewFastScroller_supportSwipeToRefresh,false))
+            if (it.getBoolean(R.styleable.RecyclerViewFastScroller_supportSwipeToRefresh,false)) {
                 enableNestedScrolling()
+            }
 
             //align added layouts based on configurations in use.
             alignTrackAndHandle()

--- a/recyclerviewfastscroller/src/main/res/values/attrs.xml
+++ b/recyclerviewfastscroller/src/main/res/values/attrs.xml
@@ -18,5 +18,6 @@
         <attr name="handleWidth" format="dimension"/>
         <attr name="handleHeight" format="dimension"/>
         <attr name="handleHasFixedSize" format="boolean"/>
+        <attr name="supportSwipeToRefresh" format="boolean"/>
     </declare-styleable>
  </resources>

--- a/sample/src/main/java/com/qtalk/sample/fragments/BasicFragment.kt
+++ b/sample/src/main/java/com/qtalk/sample/fragments/BasicFragment.kt
@@ -1,17 +1,32 @@
 package com.qtalk.sample.fragments
 
 import android.os.Bundle
+import android.os.Handler
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.qtalk.sample.R
 import com.qtalk.sample.adapters.BasicAdapter
 import kotlinx.android.synthetic.main.fragment_basic.view.*
 
 class BasicFragment : Fragment(){
+
+    private var swipeRefreshLayout:SwipeRefreshLayout? = null
+
+    private val swipeHandler by lazy {
+        Handler()
+    }
+
+    private val swipeRunnable by lazy {
+        Runnable {
+            if (swipeRefreshLayout?.isRefreshing == true)
+                swipeRefreshLayout?.isRefreshing = false
+        }
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_basic, container, false)
@@ -26,6 +41,19 @@ class BasicFragment : Fragment(){
                 adapter = BasicAdapter(activity)
                 addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
             }
+
+            with(this.swipe_refresh_layout){
+                swipeRefreshLayout = this
+                setOnRefreshListener {
+                    swipeHandler.postDelayed(swipeRunnable,3000L)
+                }
+            }
         }
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        swipeHandler.removeCallbacks(swipeRunnable)
+    }
+
 }

--- a/sample/src/main/res/layout/fragment_basic.xml
+++ b/sample/src/main/res/layout/fragment_basic.xml
@@ -1,15 +1,24 @@
-<com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller android:layout_width="match_parent"
-    android:layout_height="match_parent"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/fast_scroller"
-    app:handleWidth="@dimen/default_handle_size"
-    app:handleHeight="32dp"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-<androidx.recyclerview.widget.RecyclerView
-    android:layout_height="match_parent"
+    android:id="@+id/swipe_refresh_layout"
     android:layout_width="match_parent"
-    android:id="@+id/basic_recycler_view"
-    android:layout_marginLeft="@dimen/recycler_view_margin"
-    android:layout_marginRight="@dimen/recycler_view_margin">
-</androidx.recyclerview.widget.RecyclerView>
-</com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller>
+    android:layout_height="match_parent">
+
+    <com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller
+        android:id="@+id/fast_scroller"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:handleHeight="32dp"
+        app:handleWidth="@dimen/default_handle_size"
+        app:supportSwipeToRefresh="true">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/basic_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="@dimen/recycler_view_margin"
+            android:layout_marginRight="@dimen/recycler_view_margin" />
+
+    </com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
Fixed Fast scroller issue where the thumb is not scrollable when parent is SwipeRefreshLayout, so added custom attribute "supportSwipeToRefresh" to enable support for fast scrolling when parent layout is SwipeRefreshLayout.

Fixes #8 