### PR TITLE
For #16 add a grid layout option to the basic tab

### DIFF
--- a/sample/src/main/java/com/qtalk/sample/fragments/BasicFragment.kt
+++ b/sample/src/main/java/com/qtalk/sample/fragments/BasicFragment.kt
@@ -6,11 +6,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.qtalk.sample.R
 import com.qtalk.sample.adapters.BasicAdapter
 import kotlinx.android.synthetic.main.fragment_basic.view.*
 import kotlinx.coroutines.*
+
 
 class BasicFragment : Fragment() {
 
@@ -18,16 +21,33 @@ class BasicFragment : Fragment() {
 
     private var swipeJob: Job? = null
 
+    private var horizontalDividerItemDecoration: DividerItemDecoration? = null
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_basic, container, false)
+        return inflater.inflate(R.layout.fragment_basic, container, false).apply {
+            fab.setOnClickListener {
+                if (basic_recycler_view.layoutManager is GridLayoutManager) {
+                    basic_recycler_view.layoutManager = LinearLayoutManager(context)
+                    basic_recycler_view.removeItemDecoration(horizontalDividerItemDecoration!!)
+                    fab.setImageResource(R.drawable.ic_action_view_as_grid)
+                } else {
+                    basic_recycler_view.layoutManager = GridLayoutManager(context, 2)
+                    basic_recycler_view.addItemDecoration(horizontalDividerItemDecoration!!)
+                    fab.setImageResource(R.drawable.ic_action_view_as_list)
+                }
+            }
+
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        horizontalDividerItemDecoration = DividerItemDecoration(context, DividerItemDecoration.HORIZONTAL)
 
         with(view) {
             with(this.basic_recycler_view) {

--- a/sample/src/main/res/drawable/ic_action_view_as_grid.xml
+++ b/sample/src/main/res/drawable/ic_action_view_as_grid.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:tint="?attr/colorControlNormal"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M13,13v8h8v-8h-8zM3,21h8v-8L3,13v8zM3,3v8h8L11,3L3,3zM13,3v8h8v-8h-8z"/>
+</vector>

--- a/sample/src/main/res/drawable/ic_action_view_as_list.xml
+++ b/sample/src/main/res/drawable/ic_action_view_as_list.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:tint="?attr/colorControlNormal"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,15h16v-2L4,13v2zM4,19h16v-2L4,17v2zM4,11h16L20,9L4,9v2zM4,5v2h16L20,5L4,5z"/>
+</vector>

--- a/sample/src/main/res/layout/fragment_basic.xml
+++ b/sample/src/main/res/layout/fragment_basic.xml
@@ -1,26 +1,41 @@
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
     android:id="@+id/swipe_refresh_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller
-        android:id="@+id/fastScroller"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:handleHeight="32dp"
-        app:handleWidth="@dimen/default_handle_size"
-        app:supportSwipeToRefresh="true"
-        app:handleVisibilityDuration="500">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/basic_recycler_view"
+        <com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller
+            android:id="@+id/fastScroller"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginLeft="@dimen/recycler_view_margin"
-            android:layout_marginRight="@dimen/recycler_view_margin"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+            app:handleHeight="32dp"
+            app:handleWidth="@dimen/default_handle_size"
+            app:supportSwipeToRefresh="true"
+            app:handleVisibilityDuration="500">
 
-    </com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/basic_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginLeft="@dimen/recycler_view_margin"
+                android:layout_marginRight="@dimen/recycler_view_margin"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        </com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller>
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:srcCompat="@drawable/ic_action_view_as_grid" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR demonstrates that the fast scroller does work with a GridLayoutManager. Instead of adding a fragment with a grid layout, I've added a button to toggle list and grid layouts. Because this is what I need in my app.

![image](https://user-images.githubusercontent.com/428304/107120785-31337500-688f-11eb-9a3b-dd8714c01f52.png)

![image](https://user-images.githubusercontent.com/428304/107120807-588a4200-688f-11eb-9858-a96c436d5d4e.png)
